### PR TITLE
[NGC-446] Return 404:not found instead of 410: gone 

### DIFF
--- a/redirector/admin.py
+++ b/redirector/admin.py
@@ -24,10 +24,14 @@ class RedirectAdmin(GenericAdminModelAdmin):
         ),
     )
 
-    list_display = ('from_url', 'final_destination', 'site', 'content_object', 'to_url')
+    list_display = ('from_url', 'final_destination', 'site', 'get_content_object', 'to_url')
     list_filter = ('site', 'content_type')
     search_fields = ('from_url', 'to_url', 'object_id')
     ordering = ('from_url',)
+
+    def get_content_object(self, instance):
+        return unicode(instance.content_object)
+    get_content_object.short_description = u'Content object'
 
     def final_destination(self, instance):
         """Show the redirect's final destination URL."""

--- a/redirector/middleware/__init__.py
+++ b/redirector/middleware/__init__.py
@@ -1,7 +1,7 @@
 import urlparse
 
 from django.conf import settings
-from django.http import HttpResponseGone, HttpResponsePermanentRedirect, Http404
+from django.http import HttpResponsePermanentRedirect, Http404
 
 from ..models import Redirect
 
@@ -34,7 +34,7 @@ class RedirectMiddleware(object):
 
         if r is not None:
             if not any([hasattr(r.content_object, 'get_absolute_url'), r.to_url]):
-                return HttpResponseGone()
+                return Http404()
 
             if not r.to_url:
                 # It's a redirect to a content object.


### PR DESCRIPTION
## Jira

https://jira.nationalgeographic.com/browse/NGC-446
## Work
- Changed 410 to 404
- Refactor on `list_display` for Django 1.6 or higher
